### PR TITLE
Introduce an intermediate representation for road

### DIFF
--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -52,6 +52,9 @@ public class BoardManager : MonoBehaviour, IInitializable
 	[Inject]
 	Installer.Settings.RoadTiles roadTiles;
 
+	[Inject]
+	RoadBuilder roadBuilder;
+
     [Inject]
     RoadDrawer roadDrawer;
 
@@ -111,7 +114,8 @@ public class BoardManager : MonoBehaviour, IInitializable
 	private void SetupRoute() 
 	{
 		GameObject cfcOrigin = SetupOrigin (currentLevel.origin);
-		GameObject[] roadObjects = roadDrawer.SetupRoadSegments(currentLevel.path);
+		RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments (currentLevel.path);
+		GameObject[] roadObjects = roadDrawer.DrawRoad(roadSegments);
 		foreach (GameObject roadObject in roadObjects) {
 			Coordinate currCoord = new Coordinate(roadObject.transform.position);
 			roadCoordinates.Add(currCoord);

--- a/Assets/Scripts/Editor/RoadDrawerTest.cs
+++ b/Assets/Scripts/Editor/RoadDrawerTest.cs
@@ -37,6 +37,7 @@ namespace Tests
             _container.BindInstance(translatorMock);
             _container.BindInstance(roadTilesMock);
             _container.Bind<RoadDrawer>().ToSingleGameObject();
+            _container.Bind<RoadBuilder>().ToSingleGameObject();
         }
 
         [Test]
@@ -45,10 +46,13 @@ namespace Tests
             nodes[0].connectedNodes = new int[] { 1 };
             nodes[1].connectedNodes = new int[] { 0 };
 
-            var roadDrawer = _container.Resolve<RoadDrawer>();
-            GameObject[] gameObjects = roadDrawer.SetupRoadSegments(nodes);
-            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(0, 0, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[1], "DeadEnd(Clone)", new Vector3(1, 0, 0), Direction.West);
+			var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+
+            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 0, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[1], "DeadEnd(Clone)", new Vector3(3, 0, 0), Direction.West);
         }
 
         [Test]
@@ -61,11 +65,15 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 2 };
 
             var roadDrawer = _container.Resolve<RoadDrawer>();
-            GameObject[] gameObjects = roadDrawer.SetupRoadSegments(nodes);
-            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(0, 0, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[1], "Straight(Clone)", new Vector3(1, 0, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[2], "Straight(Clone)", new Vector3(2, 0, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(3, 0, 0), Direction.West);
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+
+
+            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 0, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[1], "Straight(Clone)", new Vector3(3, 0, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[2], "Straight(Clone)", new Vector3(4, 0, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(5, 0, 0), Direction.West);
         }
 
         [Test]
@@ -77,12 +85,15 @@ namespace Tests
             nodes[2].connectedNodes = new int[] { 1, 3 };
             nodes[3].connectedNodes = new int[] { 2 };
 
-            var roadDrawer = _container.Resolve<RoadDrawer>();
-            GameObject[] gameObjects = roadDrawer.SetupRoadSegments(nodes);
-            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(0, 3, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(1, 3, 0), Direction.West);
-            AssertThatRoadSegmentIsCorrect(gameObjects[2], "Straight(Clone)", new Vector3(1, 4, 0), Direction.North);
-            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(1, 5, 0), Direction.South);
+			var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+
+            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(3, 3, 0), Direction.West);
+            AssertThatRoadSegmentIsCorrect(gameObjects[2], "Straight(Clone)", new Vector3(3, 4, 0), Direction.North);
+            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(3, 5, 0), Direction.South);
         }
 
         [Test]
@@ -94,12 +105,15 @@ namespace Tests
             nodes[2].connectedNodes = new int[] { 1, 3 };
             nodes[3].connectedNodes = new int[] { 2 };
 
-            var roadDrawer = _container.Resolve<RoadDrawer>();
-            GameObject[] gameObjects = roadDrawer.SetupRoadSegments(nodes);
-            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(0, 3, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(1, 3, 0), Direction.South);
-            AssertThatRoadSegmentIsCorrect(gameObjects[2], "Straight(Clone)", new Vector3(1, 2, 0), Direction.South);
-            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(1, 1, 0), Direction.North);
+			var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+
+            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(3, 3, 0), Direction.South);
+            AssertThatRoadSegmentIsCorrect(gameObjects[2], "Straight(Clone)", new Vector3(3, 2, 0), Direction.South);
+            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(3, 1, 0), Direction.North);
         }
 
         [Test]
@@ -110,12 +124,15 @@ namespace Tests
             nodes[2].connectedNodes = new int[] { 1 };
             nodes[3].connectedNodes = new int[] { 1 };
 
-            var roadDrawer = _container.Resolve<RoadDrawer>();
-            GameObject[] gameObjects = roadDrawer.SetupRoadSegments(nodes);
-            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(0, 3, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[1], "TJunction(Clone)", new Vector3(1, 3, 0), Direction.West);
-            AssertThatRoadSegmentIsCorrect(gameObjects[2], "DeadEnd(Clone)", new Vector3(1, 4, 0), Direction.South);
-            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(1, 2, 0), Direction.North);
+			var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+
+            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[1], "TJunction(Clone)", new Vector3(3, 3, 0), Direction.West);
+            AssertThatRoadSegmentIsCorrect(gameObjects[2], "DeadEnd(Clone)", new Vector3(3, 4, 0), Direction.South);
+            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(3, 2, 0), Direction.North);
         }
 
         [Test]
@@ -127,13 +144,16 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 1 };
             nodes[4].connectedNodes = new int[] { 1 };
 
-            var roadDrawer = _container.Resolve<RoadDrawer>();
-            GameObject[] gameObjects = roadDrawer.SetupRoadSegments(nodes);
-            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(0, 3, 0), Direction.East);
-            AssertThatRoadSegmentIsCorrect(gameObjects[1], "CrossRoad(Clone)", new Vector3(1, 3, 0), Direction.North);
-            AssertThatRoadSegmentIsCorrect(gameObjects[2], "DeadEnd(Clone)", new Vector3(1, 4, 0), Direction.South);
-            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(1, 2, 0), Direction.North);
-            AssertThatRoadSegmentIsCorrect(gameObjects[4], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.West);
+			var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+
+            AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
+            AssertThatRoadSegmentIsCorrect(gameObjects[1], "CrossRoad(Clone)", new Vector3(3, 3, 0), Direction.North);
+            AssertThatRoadSegmentIsCorrect(gameObjects[2], "DeadEnd(Clone)", new Vector3(3, 4, 0), Direction.South);
+            AssertThatRoadSegmentIsCorrect(gameObjects[3], "DeadEnd(Clone)", new Vector3(3, 2, 0), Direction.North);
+            AssertThatRoadSegmentIsCorrect(gameObjects[4], "DeadEnd(Clone)", new Vector3(4, 3, 0), Direction.West);
         }
 
         private void AssertThatRoadSegmentIsCorrect(GameObject roadSegment, string name, Vector3 position, Direction direction) {

--- a/Assets/Scripts/Editor/RoadDrawerTest.cs
+++ b/Assets/Scripts/Editor/RoadDrawerTest.cs
@@ -46,10 +46,10 @@ namespace Tests
             nodes[0].connectedNodes = new int[] { 1 };
             nodes[1].connectedNodes = new int[] { 0 };
 
-			var roadDrawer = _container.Resolve<RoadDrawer>();
-			var roadBuilder = _container.Resolve<RoadBuilder>();
-			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+            var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+            RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 0, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "DeadEnd(Clone)", new Vector3(3, 0, 0), Direction.West);
@@ -65,9 +65,9 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 2 };
 
             var roadDrawer = _container.Resolve<RoadDrawer>();
-			var roadBuilder = _container.Resolve<RoadBuilder>();
-			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+            RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 0, 0), Direction.East);
@@ -85,10 +85,10 @@ namespace Tests
             nodes[2].connectedNodes = new int[] { 1, 3 };
             nodes[3].connectedNodes = new int[] { 2 };
 
-			var roadDrawer = _container.Resolve<RoadDrawer>();
-			var roadBuilder = _container.Resolve<RoadBuilder>();
-			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+            var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+            RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(3, 3, 0), Direction.West);
@@ -105,10 +105,10 @@ namespace Tests
             nodes[2].connectedNodes = new int[] { 1, 3 };
             nodes[3].connectedNodes = new int[] { 2 };
 
-			var roadDrawer = _container.Resolve<RoadDrawer>();
-			var roadBuilder = _container.Resolve<RoadBuilder>();
-			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+            var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+            RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(3, 3, 0), Direction.South);
@@ -124,10 +124,10 @@ namespace Tests
             nodes[2].connectedNodes = new int[] { 1 };
             nodes[3].connectedNodes = new int[] { 1 };
 
-			var roadDrawer = _container.Resolve<RoadDrawer>();
-			var roadBuilder = _container.Resolve<RoadBuilder>();
-			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+            var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+            RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "TJunction(Clone)", new Vector3(3, 3, 0), Direction.West);
@@ -144,10 +144,10 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 1 };
             nodes[4].connectedNodes = new int[] { 1 };
 
-			var roadDrawer = _container.Resolve<RoadDrawer>();
-			var roadBuilder = _container.Resolve<RoadBuilder>();
-			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+            var roadDrawer = _container.Resolve<RoadDrawer>();
+            var roadBuilder = _container.Resolve<RoadBuilder>();
+            RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
+            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "CrossRoad(Clone)", new Vector3(3, 3, 0), Direction.North);

--- a/Assets/Scripts/Editor/RoadDrawerTest.cs
+++ b/Assets/Scripts/Editor/RoadDrawerTest.cs
@@ -47,9 +47,9 @@ namespace Tests
             nodes[1].connectedNodes = new int[] { 0 };
 
 			var roadDrawer = _container.Resolve<RoadDrawer>();
-            var roadBuilder = _container.Resolve<RoadBuilder>();
+			var roadBuilder = _container.Resolve<RoadBuilder>();
 			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 0, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "DeadEnd(Clone)", new Vector3(3, 0, 0), Direction.West);
@@ -65,9 +65,9 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 2 };
 
             var roadDrawer = _container.Resolve<RoadDrawer>();
-            var roadBuilder = _container.Resolve<RoadBuilder>();
+			var roadBuilder = _container.Resolve<RoadBuilder>();
 			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 0, 0), Direction.East);
@@ -86,9 +86,9 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 2 };
 
 			var roadDrawer = _container.Resolve<RoadDrawer>();
-            var roadBuilder = _container.Resolve<RoadBuilder>();
+			var roadBuilder = _container.Resolve<RoadBuilder>();
 			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(3, 3, 0), Direction.West);
@@ -106,9 +106,9 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 2 };
 
 			var roadDrawer = _container.Resolve<RoadDrawer>();
-            var roadBuilder = _container.Resolve<RoadBuilder>();
+			var roadBuilder = _container.Resolve<RoadBuilder>();
 			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "Turn(Clone)", new Vector3(3, 3, 0), Direction.South);
@@ -125,9 +125,9 @@ namespace Tests
             nodes[3].connectedNodes = new int[] { 1 };
 
 			var roadDrawer = _container.Resolve<RoadDrawer>();
-            var roadBuilder = _container.Resolve<RoadBuilder>();
+			var roadBuilder = _container.Resolve<RoadBuilder>();
 			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "TJunction(Clone)", new Vector3(3, 3, 0), Direction.West);
@@ -145,9 +145,9 @@ namespace Tests
             nodes[4].connectedNodes = new int[] { 1 };
 
 			var roadDrawer = _container.Resolve<RoadDrawer>();
-            var roadBuilder = _container.Resolve<RoadBuilder>();
+			var roadBuilder = _container.Resolve<RoadBuilder>();
 			RoadSegment[] roadSegments = roadBuilder.CreateRoadSegments(nodes);
-            GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
+			GameObject[] gameObjects = roadDrawer.DrawRoad(roadSegments);
 
             AssertThatRoadSegmentIsCorrect(gameObjects[0], "DeadEnd(Clone)", new Vector3(2, 3, 0), Direction.East);
             AssertThatRoadSegmentIsCorrect(gameObjects[1], "CrossRoad(Clone)", new Vector3(3, 3, 0), Direction.North);

--- a/Assets/Scripts/Installer.cs
+++ b/Assets/Scripts/Installer.cs
@@ -14,6 +14,7 @@ public class Installer : MonoInstaller
         Container.Bind<GameManager>().ToSingle();
         Container.Bind<BoardManager>().ToSingleGameObject();
         Container.Bind<BoardTranslator>().ToSingle();
+		Container.Bind<RoadBuilder>().ToSingleGameObject();
         Container.Bind<RoadDrawer>().ToSingleGameObject();
         Container.Bind<DecorDrawer>().ToSingleGameObject();
         InstallSettings();

--- a/Assets/Scripts/Installer.cs
+++ b/Assets/Scripts/Installer.cs
@@ -14,7 +14,7 @@ public class Installer : MonoInstaller
         Container.Bind<GameManager>().ToSingle();
         Container.Bind<BoardManager>().ToSingleGameObject();
         Container.Bind<BoardTranslator>().ToSingle();
-		Container.Bind<RoadBuilder>().ToSingleGameObject();
+        Container.Bind<RoadBuilder>().ToSingleGameObject();
         Container.Bind<RoadDrawer>().ToSingleGameObject();
         Container.Bind<DecorDrawer>().ToSingleGameObject();
         InstallSettings();

--- a/Assets/Scripts/RoadBuilder.cs
+++ b/Assets/Scripts/RoadBuilder.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Zenject;
+
+namespace Road
+{
+
+	public enum RoadType : int
+	{
+		DeadEnd = 1,
+		Straight = 2,
+		Turn = 3,
+		TJunction = 4,
+		CrossRoads = 5
+	}
+
+	public class RoadSegment
+	{
+		public RoadType roadType;
+		public Coordinate coords;
+		public Direction direction;
+
+		public RoadSegment (RoadType roadType, Coordinate coords, Direction direction)
+		{
+			this.roadType = roadType;
+			this.coords = coords;
+			this.direction = direction;
+		}
+	}
+
+	public class RoadBuilder : MonoBehaviour
+	{
+		public RoadSegment[] CreateRoadSegments (PathNode[] nodes)
+		{
+			RoadSegment[] roadSegments = new RoadSegment[nodes.Length];
+			for (int currentIndex = 0; currentIndex < nodes.Length; currentIndex++) {
+				roadSegments [currentIndex] = CreateRoadSegment (nodes, currentIndex);
+			}
+			return roadSegments;
+		}
+
+		private RoadSegment CreateRoadSegment (PathNode[] nodes, int currentNodeIndex)
+		{
+			PathNode node = nodes [currentNodeIndex];
+			switch (node.connectedNodes.Length) {
+			case 1:
+				return CreateDeadEnd (node.coords, nodes [node.connectedNodes [0]].coords);
+			case 2:
+				return CreateStraightOrTurn (nodes, node);
+			case 3:
+				return CreateTJunction (nodes, node);
+			case 4:
+				return CreateCrossRoad (node);
+			default:
+				// we don't currently support lone pieces of road
+				return null;
+			}
+		}
+
+		private RoadSegment CreateDeadEnd (Coordinate coords, Coordinate neighbourCoords)
+		{
+			Direction direction = RelativeDirection (coords, neighbourCoords);
+			return new RoadSegment (RoadType.DeadEnd, coords, direction);
+		}
+
+		private RoadSegment CreateStraightOrTurn (PathNode[] nodes, PathNode node)
+		{
+			PathNode neighbour1 = nodes [node.connectedNodes [0]];
+			PathNode neighbour2 = nodes [node.connectedNodes [1]];
+
+			return CreateStraightOrTurn (node.coords, neighbour1.coords, neighbour2.coords);
+		}
+
+		private RoadSegment CreateStraightOrTurn (Coordinate coords, Coordinate neighbour1, Coordinate neighbour2)
+		{
+			Direction direction1 = RelativeDirection (coords, neighbour1);
+			Direction direction2 = RelativeDirection (coords, neighbour2);
+			if (AreOppositeDirections (direction1, direction2)) {
+				return new RoadSegment (RoadType.Straight, coords, direction2);
+			} else {
+				return CreateTurn (coords, direction1, direction2);
+			}
+		}
+
+		private RoadSegment CreateTurn (Coordinate coords, Direction direction1, Direction direction2)
+		{
+			Direction direction = GetRotationAngleForTurnRoad (direction1, direction2);
+			return new RoadSegment (RoadType.Turn, coords, direction);
+		}
+
+		private RoadSegment CreateTJunction (PathNode[] nodes, PathNode node)
+		{
+			PathNode neighbour1 = nodes [node.connectedNodes [0]];
+			PathNode neighbour2 = nodes [node.connectedNodes [1]];
+			PathNode neighbour3 = nodes [node.connectedNodes [2]];
+
+			return CreateTJunction (node.coords, neighbour1.coords, neighbour2.coords, neighbour3.coords);
+		}
+
+		private RoadSegment CreateTJunction (Coordinate coords, Coordinate neighbour1, Coordinate neighbour2, Coordinate neighbour3)
+		{
+			Direction direction1 = RelativeDirection (coords, neighbour1);
+			Direction direction2 = RelativeDirection (coords, neighbour2);
+			Direction direction3 = RelativeDirection (coords, neighbour3);
+			Direction rotationAngle = GetRotationAngleForTJunctionRoad (direction1, direction2, direction3);
+			return new RoadSegment (RoadType.TJunction, coords, rotationAngle);
+		}
+
+		private RoadSegment CreateCrossRoad (PathNode node)
+		{
+			return new RoadSegment (RoadType.CrossRoads, node.coords, Direction.North);
+		}
+
+		private Direction RelativeDirection (Coordinate subjectCoords, Coordinate otherCoords)
+		{
+			if (subjectCoords.x < otherCoords.x) {
+				return Direction.East;
+			} else if (subjectCoords.x > otherCoords.x) {
+				return Direction.West;
+			} else if (subjectCoords.y < otherCoords.y) {
+				return Direction.North;
+			} else if (subjectCoords.y > otherCoords.y) {
+				return Direction.South;
+			}
+			// should never get here
+			return Direction.North;
+		}
+
+		private Direction GetRotationAngleForTurnRoad (Direction direction1, Direction direction2)
+		{
+			HashSet<Direction> directions = new HashSet<Direction> ();
+			directions.Add (direction1);
+			directions.Add (direction2);
+
+			if (directions.Contains (Direction.North) && directions.Contains (Direction.East)) {
+				return Direction.North;
+			} else if (directions.Contains (Direction.South) && directions.Contains (Direction.East)) {
+				return Direction.East;
+			} else if (directions.Contains (Direction.North) && directions.Contains (Direction.West)) {
+				return Direction.West;
+			} else if (directions.Contains (Direction.South) && directions.Contains (Direction.West)) {
+				return Direction.South;
+			}
+
+			return Direction.North;
+		}
+
+		private Direction GetRotationAngleForTJunctionRoad (Direction direction1, Direction direction2, Direction direction3)
+		{
+			HashSet<Direction> directions = new HashSet<Direction> ();
+			directions.Add (direction1);
+			directions.Add (direction2);
+			directions.Add (direction3);
+			if (directions.Contains (Direction.North) && directions.Contains (Direction.South)) {
+				directions.Remove (Direction.North);
+				directions.Remove (Direction.South);
+			} else if (directions.Contains (Direction.West) && directions.Contains (Direction.East)) {
+				directions.Remove (Direction.West);
+				directions.Remove (Direction.East);
+			}
+			Direction direction = Direction.North;
+			foreach (Direction directionValue in directions) {
+				direction = directionValue;
+			}
+			return direction;
+		}
+
+		private bool AreOppositeDirections (Direction direction1, Direction direction2)
+		{
+			HashSet<Direction> directions = new HashSet<Direction> ();
+			directions.Add (direction1);
+			directions.Add (direction2);
+			return (directions.Contains (Direction.North) && directions.Contains (Direction.South)) ||
+			(directions.Contains (Direction.West) && directions.Contains (Direction.East));
+		}
+
+	}
+}

--- a/Assets/Scripts/RoadBuilder.cs.meta
+++ b/Assets/Scripts/RoadBuilder.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: da1dabe8c4fd440c599a058bf9912366
+timeCreated: 1502298171
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Creates a RoadSegment type and a RoadBuilder to create a list of these from the loaded Level. By storing the type of road segment (turn, t-junction, etc) rather than just coordinates, it should be easier to draw additional details onto the road later.

(This is the same as the last MR, but without the commit spam)